### PR TITLE
Redmine refactoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ create virtualenv with system packages::
     virtualenv --system-site-packages path/to/hamster-bridge-env
     source path/to/hamster-bridge-env/bin/activate
 
+JIRA
+----
+
 install via pip::
 
     pip install hamster-bridge
@@ -22,7 +25,14 @@ then run it with::
 
     hamster-bridge jira
 
-or::
+Redmine
+-------
+
+install via pip::
+
+    pip install hamster-bridge[redmine]
+
+then run it with::
 
     hamster-bridge redmine
 

--- a/README.rst
+++ b/README.rst
@@ -67,10 +67,13 @@ Upon start of the hamster-bridge, all activities will be listed:
     2015-03-01 14:23:31,437    INFO: Start listening for hamster activity...
 
 If you set the name of an activity as tag, it will be used for the created time entry. If you do not specify a tag, the first activity (and usually the default
-one in Redmine) will be used. If you specify more than one activity as tag value, the first found will be used.
-You can mix the activity tags with other tags - the first found tag that matches the name of an activity will be used for the entry.
+one in Redmine) will be used. If you specify more than one activity as tag value, the first found will be used (but see the hints below!).
+You can mix the activity tags with other tags - the first found tag that matches the name of an activity will be used for the entry (see the hints, too).
 
-*Hint:* activity names are case sensitive!
+*Important hints:*
+* activity names are case sensitive
+* hamster is sorting the tags alphabetically
+** if you e.g. set the tags "Development" and "Design" in this order, hamster will sort them to ['Design', 'Development'] thus the time entry will be attached to "Design"
 
 
 license

--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,10 @@ one in Redmine) will be used. If you specify more than one activity as tag value
 You can mix the activity tags with other tags - the first found tag that matches the name of an activity will be used for the entry (see the hints, too).
 
 *Important hints:*
+
 * activity names are case sensitive
 * hamster is sorting the tags alphabetically
-** if you e.g. set the tags "Development" and "Design" in this order, hamster will sort them to ['Design', 'Development'] thus the time entry will be attached to "Design"
+    * if you e.g. set the tags "Development" and "Design" in this order, hamster will sort them to ['Design', 'Development'] thus the time entry will be attached to "Design"
 
 
 license

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,32 @@ usage
 
 Problems? Don't work for you? Open up an issue here together with the debug output (start the bridge with "-d").
 
+hints on redmine
+----------------
+
+Redmine behaves slightly different than JIRA. For each time entry that is created, an activity has to be chosen. Within the Redmine installation a default
+activity *can* be defined but usually this is not the way the installation is set up. Therefore one must be able to select the activity when creating a time
+entry. As the hamster does not offer any field for such activity, we instead use the tags field.
+Upon start of the hamster-bridge, all activities will be listed:
+
+::
+
+    2015-03-01 14:23:31,001    INFO: Starting hamster bridge
+    2015-03-01 14:23:31,003    INFO: ### Available Redmine activities for using as tag value:
+    2015-03-01 14:23:31,011    INFO: Starting new HTTPS connection (1): redmine.yourhost.com
+    2015-03-01 14:23:31,229    INFO: ### Development
+    2015-03-01 14:23:31,229    INFO: ### Design
+    2015-03-01 14:23:31,230    INFO: ### Deployment
+    2015-03-01 14:23:31,230    INFO: Starting new HTTPS connection (1): redmine.yourhost.com
+    2015-03-01 14:23:31,437    INFO: Start listening for hamster activity...
+
+If you set the name of an activity as tag, it will be used for the created time entry. If you do not specify a tag, the first activity (and usually the default
+one in Redmine) will be used. If you specify more than one activity as tag value, the first found will be used.
+You can mix the activity tags with other tags - the first found tag that matches the name of an activity will be used for the entry.
+
+*Hint:* activity names are case sensitive!
+
+
 license
 =======
 MIT-License, see LICENSE file.

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
-import json
 import logging
 import re
-import requests
 
 from hamster_bridge.listeners import HamsterListener
 
@@ -20,7 +18,7 @@ logger = logging.getLogger(__name__)
 class RedmineHamsterListener(HamsterListener):
     """
     Redmine listener for hamster tasks,
-    Tested with Redmine 2.2.2.stable
+    Tested with Redmine 2.5.1.stable
 
     Important: will only work with German or English installation!
 
@@ -56,16 +54,9 @@ class RedmineHamsterListener(HamsterListener):
         """
         Sets up the class be defining some internal variables.
         """
-        # FIXME still necessary?
-        # will store the issue statuses as returned by Redmine API during the call of RedmineHamsterListener.prepare
-        self.__issues_statuses = []
-        # FIXME still necessary?
-        # will store the issue data, will be updated per issue whenever an issue is requested on the API
-        self.__issues = {}
-        # FIXME still necessary?
         # issue status dict for the default issue status
         self.__issue_status_default = None
-        # FIXME still necessary?
+
         # issue status dict for the "in Work" status
         self.__issue_status_in_work = None
 
@@ -74,113 +65,6 @@ class RedmineHamsterListener(HamsterListener):
 
         # will store the activities
         self.__activities = {}
-
-        # will store the currently active issue
-        self.issue = None
-
-    # FIXME still necessary?
-    def __request_resource(self, resource, method='get', data=None):
-        """
-        Request the given resource from the Redmine API using the given method.
-        If method is PUT or POST, also sent the given data.
-
-        :param resource: the URL to call on Redmine API
-        :type resource: str
-        :param method: the HTTP method
-        :type method: str
-        :param data: the data to put if method is PUT or POST
-        :type data: str
-        """
-        kwargs = {
-            'headers': {
-                'X-Redmine-API-Key': self.config.get(self.short_name, 'api_key'),
-                'content-type': 'application/json',
-            },
-            'verify': True if self.config.get(self.short_name, 'verify_ssl') == 'y' else False,
-        }
-
-        if data is not None and (method == 'put' or method == 'post'):
-            kwargs['data'] = data
-
-        url = self.config.get(self.short_name, 'server_url')
-        if not url.endswith('/'):
-            url += '/'
-
-        return getattr(requests, method)(
-            '%(url)s%(resource)s' % {
-                'url': url,
-                'resource': resource,
-            },
-            **kwargs
-        )
-
-    # FIXME still necessary?
-    def __update_issue(self, issue_id, data):
-        """
-        Updates the issue with the given id with the given data.
-
-        :param issue_id: the id of the issue
-        :type issue_id: str
-        :param data: the data to update
-        :type data: dict
-        """
-        req = self.__request_resource(
-            self.resources['issue'] % {'issue_id': issue_id},
-            method='put',
-            data=json.dumps(data),
-        )
-        if req.status_code != 200:
-            logger.error('Unable to set issue %(issue_id)s to data %(data)s.' % {'issue_id': issue_id, 'data': data})
-
-    # FIXME still necessary?
-    def __log_work(self, issue_number, date_spent_on, time_spent):
-        """
-        Logs work to Redmine with the given values.
-
-        :param issue_number: the issue to log to
-        :type issue_number: str
-        :param date_spent_on: the date the time was spent
-        :type date_spent_on: datetime.date
-        :param time_spent: the amount of time that was spent
-        :type time_spent: str
-        """
-        req = self.__request_resource(
-            self.resources['time_entries'],
-            method='post',
-            data=json.dumps(
-                {
-                    'time_entry': {
-                        'issue_id': issue_number,
-                        'spent_on': date_spent_on.strftime('%Y-%m-%d'),
-                        'hours': time_spent,
-                    }
-                }
-            )
-        )
-        if req.status_code == 201:
-            logger.info('Logged work: %(time_spent)s to %(issue)s on %(date_spent_on)s' % {
-                'time_spent': time_spent,
-                'issue': issue_number,
-                'date_spent_on': date_spent_on,
-            })
-        else:
-            logger.error('Unable to log time to Redmine. HTTP status code was %s with error %s', req.status_code, req.text)
-
-    # FIXME still necessary?
-    def __exists_issue(self, issue_id):
-        """
-        Checks if an issue with the given issue_id exists by calling the Redmine API,
-
-        :param issue_id: the issue id
-        :type issue_id: str
-        """
-        req = self.__request_resource(self.resources['issue'] % {'issue_id': issue_id})
-        if req.status_code == 200:
-            # cache the issue values for later use
-            self.__issues[issue_id] = req.json()['issue']
-            return True
-
-        return False
 
     def __get_issue_from_fact(self, fact):
         """
@@ -273,23 +157,20 @@ class RedmineHamsterListener(HamsterListener):
         # if issue shall be auto started...
         if self.config.get(self.short_name, 'auto_start') == 'y':
             # fetch the issue from the hamster fact
-            self.issue = self.__get_issue_from_fact(fact)
+            issue = self.__get_issue_from_fact(fact)
 
-            if not self.issue:
-                logger.error('Unable to query an issue for the hamster fact %s', fact.original_activity)
+            # abort if no issue was found
+            if not issue:
+                logger.error('Unable to query issue for starting of hamster fact %s', fact.original_activity)
                 return
 
             # if the issue is in the default state (aka the initial state), put it into work state
-            if self.issue.status.id == self.__issue_status_default.id:
-                logger.info('setting status to "In Work" for issue %d', self.issue.id)
-                self.issue.status_id = self.__issue_status_in_work.id
-                self.issue.save()
+            if issue.status.id == self.__issue_status_default.id:
+                logger.info('setting status to "In Work" for issue %d', issue.id)
+                issue.status_id = self.__issue_status_in_work.id
+                issue.save()
 
-    # FIXME still necessary?
     def on_fact_stopped(self, fact):
-        # FIXME remove
-        print('on_fact_stopped', fact)
-        # TODO handle self.issue
         """
         Called by HamsterBridge if a fact is stopped.
         Will try to log the time to the appropriate Redmine issue if there is one.
@@ -298,8 +179,19 @@ class RedmineHamsterListener(HamsterListener):
         :param fact: the currently stopped fact
         :type fact: hamster.lib.stuff.Fact
         """
-        issue_id = self.__get_issue_id_from_fact(fact)
-        if issue_id is not None:
-            self.__log_work(issue_id, fact.date, '%0.2f' % (fact.delta.total_seconds() / 3600.0))
-        else:
-            logger.info('No valid issue found in "%s"', fact.activity)
+
+        # fetch the issue from the hamster fact
+        issue = self.__get_issue_from_fact(fact)
+
+        # abort if no issue was found
+        if not issue:
+            logger.error('Unable to query issue for stopping of hamster fact %s', fact.original_activity)
+            return
+
+        # create the time entry
+        self.redmine.time_entry.create(
+            issue_id=issue.id,
+            hours='%0.2f' % (fact.delta.total_seconds() / 3600.0),
+            # FIXME this grabs the first activity from the dict, it should somehow be defined.... maybe through the tags?
+            activity_id=self.__activities.itervalues().next(),
+        )

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -118,6 +118,39 @@ class RedmineHamsterListener(HamsterListener):
         except IndexError:
             logger.exception('Unable to find a single "In Work" issue status!')
 
+    def __get_first_activity_id(self):
+        """
+        Returns the first activity that was retrieved.
+        The first activity was marked with a True value.
+        :return: the id of the first activity
+        :rtype: int
+        """
+        return [key for key, value in self.__activities.items() if value[1]][0]
+
+    def __get_activity_id(self, tags):
+        """
+        Returns an activity id if it can be resolved from the list of given tags.
+        Otherwise the first found activity id is returned.
+        :param tags: list of tags
+        :type tags: list
+        :return: the activity id
+        :rtype: int
+        """
+        if len(tags) == 0:
+            # this grabs the first activity from the dict
+            return self.__get_first_activity_id()
+        else:
+            for activity_id, activity_value in self.__activities.viewitems():
+                try:
+                    next(tag for tag in tags if tag == activity_value[0])
+                    return activity_id
+                except StopIteration:
+                    # if not found
+                    continue
+
+            # fallback if no tag matches
+            return self.__get_first_activity_id()
+
     def prepare(self):
         """
         Prepares the listener by checking connectivity to configured Redmine instance.
@@ -138,8 +171,10 @@ class RedmineHamsterListener(HamsterListener):
         # only now the real http request is made, use this as connectivity check
         try:
             logger.info('### Available Redmine activities for using as tag value:')
+            is_first = True
             for tea in time_entry_activities:
-                self.__activities[tea.id] = tea.name
+                self.__activities[tea.id] = (tea.name, is_first)
+                is_first = False
                 logger.info('### ' + tea.name)
         except (BaseRedmineError, IOError):
             logger.exception('Unable to communicate with redmine server. See error in the following output:')
@@ -194,7 +229,7 @@ class RedmineHamsterListener(HamsterListener):
         self.redmine.time_entry.create(
             issue_id=issue.id,
             hours='%0.2f' % (fact.delta.total_seconds() / 3600.0),
-            # FIXME this grabs the first activity from the dict, it should somehow be defined.... maybe through the tags?
-            activity_id=self.__activities.itervalues().next(),
+            # grep the tags, convert to string (the values are dbus.String) and find an activity
+            activity_id=self.__get_activity_id([str(tag) for tag in fact.tags]),
             comments=fact.description,
         )

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -222,12 +222,12 @@ class RedmineHamsterListener(HamsterListener):
             logger.exception('Unable to fetch issue statuses! Not possible to proceed!')
 
         try:
-            self.__issue_status_default = filter(find_default, issue_statuses)[0]
+            self.__issue_status_default = [item for item in issue_statuses if find_default(item)][0]
         except IndexError:
             logger.exception('Unable to find a single default issue status!')
 
         try:
-            self.__issue_status_in_work = filter(find_in_work, issue_statuses)[0]
+            self.__issue_status_in_work = [item for item in issue_statuses if find_in_work(item)][0]
         except IndexError:
             logger.exception('Unable to find a single "In Work" issue status!')
 

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -194,4 +194,5 @@ class RedmineHamsterListener(HamsterListener):
             hours='%0.2f' % (fact.delta.total_seconds() / 3600.0),
             # FIXME this grabs the first activity from the dict, it should somehow be defined.... maybe through the tags?
             activity_id=self.__activities.itervalues().next(),
+            comments=fact.description,
         )

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -223,7 +223,6 @@ class RedmineHamsterListener(HamsterListener):
         While doing so, grabs the issue statuses, too, used for on_fact_stopped.
         """
         # setup the redmine instance
-        print(self.__get_config('server_url'))
         self.redmine = Redmine(
             self.__get_config('server_url'),
             key=self.__get_config('api_key'),
@@ -232,14 +231,14 @@ class RedmineHamsterListener(HamsterListener):
                 'verify': True if self.__get_config('verify_ssl') == 'y' else False
             }
         )
-        # fetch the possbile activities for time entries
+        # fetch the possible activities for time entries
         time_entry_activities = self.redmine.enumeration.filter(resource='time_entry_activities')
 
         # only now the real http request is made, use this as connectivity check
         try:
             for tea in time_entry_activities:
-                print(tea, tea.id, tea.name)
-        except (BaseRedmineError, IOError, ConnectionError):
+                self.__activities[tea.id] = tea.name
+        except (BaseRedmineError, IOError):
             logger.exception('Unable to communicate with redmine server. See error in the following output:')
 
 

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -137,8 +137,10 @@ class RedmineHamsterListener(HamsterListener):
 
         # only now the real http request is made, use this as connectivity check
         try:
+            logger.info('### Available Redmine activities for using as tag value:')
             for tea in time_entry_activities:
                 self.__activities[tea.id] = tea.name
+                logger.info('### ' + tea.name)
         except (BaseRedmineError, IOError):
             logger.exception('Unable to communicate with redmine server. See error in the following output:')
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setup(
     author_email='der.kraiz@gmail.com',
     license='MIT',
     url='https://github.com/kraiz/hamster-bridge',
+    extras_require={
+        'redmine': ['python-redmine'],
+    },
     packages=['hamster_bridge', 'hamster_bridge.listeners'],
     entry_points={'console_scripts': ['hamster-bridge = hamster_bridge:main']},
     long_description=open('README.rst').read() + '\n\n' + open('CHANGELOG.rst').read(),


### PR DESCRIPTION
I rewrote the Redmine listener to use python-redmine instead of hand made requests.
Possibility to add comments was also added. Rewrote the way Redmine activities are mapped, now you can set them through the tags.