### PR TITLE
Adding config-path option

### DIFF
--- a/hamster_bridge/__init__.py
+++ b/hamster_bridge/__init__.py
@@ -4,6 +4,9 @@ import logging
 from hamster_bridge.bridge import HamsterBridge
 
 
+CONFIG_PATH = '~/.hamster-bridge.cfg'
+
+
 def import_listener(name):
     components = name.rsplit('.')
     mod = __import__(name.rsplit('.', 1)[0])
@@ -29,7 +32,10 @@ def main():
     parser.add_argument('-d', '--debug', action='store_true', help='enable debug logging')
     parser.add_argument('-c', '--check-interval', default='2', type=int,
                         help='check every this amount of seconds for updates')
+    parser.add_argument('--config-path', default=CONFIG_PATH, type=str, 
+                        help='path to config file, defaults to {}'.format(CONFIG_PATH))
     args = parser.parse_args()
+    print args
 
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO,
@@ -41,7 +47,7 @@ def main():
     bridge = HamsterBridge()
     logger.debug('Activating listener: %s', args.bugtracker)
     bridge.add_listener(listener_choices[args.bugtracker]())
-    bridge.configure()
+    bridge.configure(args.config_path)
     logger.debug('Run with check interval of %ds', args.check_interval)
     bridge.run(args.check_interval)
 

--- a/hamster_bridge/__init__.py
+++ b/hamster_bridge/__init__.py
@@ -35,7 +35,6 @@ def main():
     parser.add_argument('--config-path', default=CONFIG_PATH, type=str, 
                         help='path to config file, defaults to {}'.format(CONFIG_PATH))
     args = parser.parse_args()
-    print args
 
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO,

--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -36,6 +36,8 @@ class HamsterBridge(hamster.client.Storage):
     def configure(self, config_path):
         """
         Gives each listener the chance to do something before we start the bridge's runtime loops.
+        :param config_path: path to config file
+        :type config_path:  str
         """
         path = os.path.expanduser(config_path)
         config = ConfigParser.RawConfigParser()

--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -7,7 +7,6 @@ import stat
 
 logger = logging.getLogger(__name__)
 
-CONFIG_PATH = '~/.hamster-bridge.cfg'
 
 try:
     import hamster.client
@@ -34,11 +33,11 @@ class HamsterBridge(hamster.client.Storage):
         if listener not in self._listeners:
             self._listeners.append(listener)
 
-    def configure(self):
+    def configure(self, config_path):
         """
         Gives each listener the chance to do something before we start the bridge's runtime loops.
         """
-        path = os.path.expanduser(CONFIG_PATH)
+        path = os.path.expanduser(config_path)
         config = ConfigParser.RawConfigParser()
         # read from file if exists
         if os.path.exists(path):


### PR DESCRIPTION
This adds a config-path option to hamster bridge start parameters to allow users to use a config file at some other place than the hard coded one.