### PR TITLE
Sensitive data in config, SSL certificate path & custom JIRA transition name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,46 @@ config file. If you are upgrading from an older version of **hamster-bridge**
 (where all data was stored in the config file by default) then it will continue
 to work like before because all required values are in the config file.
 
+SSL/TLS certificates
+--------------------
+
+The **verify_ssl** config entry has 3 possible values: 'y' to enable
+certificate verification with the default CA, 'n' to disable certificate
+verification (not recommended!) and the path to a CA (Certificate Authority)
+bundle containing SSL/TLS certificates. When setting a path use the **full
+path** to prevent errors.
+
+This is very valuable if the CA store that your Python environment uses by
+default does not include the CA or intermediate CA that signed the certificate
+of your JIRA/Redmine site. This is also the case if your JIRA/Redmine site uses
+a self-signed certificate.
+
+How to set it up? Get your certificate or certificate chain and store it in a
+file. Specify the path to that file in the config.
+
+For instance your can do this with *Google Chrome* by:
+
+* opening your JIRA/Redmine site
+* clicking on the small lock icon (View site information) in the address bar
+* selecting "Connection", "Certificate information", "Details"
+* clicking on "Export" and choosing "Base64-encoded ASCII, certificate chain"
+* remembering the path you stored the file under and specifying that path in
+  the **hamster-bridge** config
+
+If your JIRA/Redmine site uses a certificate signed by a globally trusted root
+CA you might want to try using a standard CA bundle. For example:
+
+* With Linux Debian based systems (e.g. Ubuntu) you could use the
+  path */etc/ssl/certs/ca-certificates.crt*
+* Download the `certifi bundle <https://certifi.io/en/latest/>`_ and use it
+
+For Redmine the **verify_ssl** option existed already and has been extended to
+also allow you to specify a CA cert bundle path. If you had previously
+specified y/n in the config it will continue to work as before.
+
+If **verify_ssl** is set to an unknown value or to an invalid path then the
+fallback is SSL/TLS certificate verification with the default CA bundle.
+
 
 problems?
 ---------
@@ -114,6 +154,9 @@ changes
 
 * feature: don't store sensitive data such as passwords in the config file
   (can be overridden with **--save-passwords**)
+* feature: add **verify_ssl** config option for JIRA and extend it for Redmine.
+  It is now possible to specify [y/n/path] where path is the path to a CA
+  certificate bundle
 
 0.5.2
 -----

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ It will ask you for your server and login and will save that data for next start
 
 usage
 =====
+
 * Start hamster and the hamster-bridge.
 * Create tasks and place a JIRA/Redmine issue name inside the task title or it's tags.
 * When you're done, stop this task.
@@ -52,8 +53,29 @@ it will read through to issue in the tag.
 Once *one* valid ticket is found, the hamster-bridge will log the spent time to this issue together with the hamster
 task description as comment.
 
-Problems? Don't work for you? Open up an `issue on GitHub <https://github.com/kraiz/hamster-bridge/issues>`_ together with the
+sensitive data (passwords)
+--------------------------
+
+Since version 0.6 by default no sensitive data is stored in the config file
+(e.g.  :code:`~/.hamster-bridge.cfg`). Currently the only data marked as
+*sensitive* is the JIRA password.
+
+Every time you start the application it will use all values found in the config
+file and interactively ask you for the missing values (e.g. JIRA password).
+
+If you want to force saving this *sensitive* data in the config file you can
+use the **--save-passwords** option. You can also manually add the data to the
+config file. If you are upgrading from an older version of **hamster-bridge**
+(where all data was stored in the config file by default) then it will continue
+to work like before because all required values are in the config file.
+
+
+problems?
+---------
+
+Don't work for you? Open up an `issue on GitHub <https://github.com/kraiz/hamster-bridge/issues>`_ together with the
 debug output (start the bridge with "-d").
+
 
 hints on redmine
 ----------------
@@ -86,6 +108,12 @@ MIT-License, see LICENSE file.
 
 changes
 =======
+
+0.6
+---
+
+* feature: don't store sensitive data such as passwords in the config file
+  (can be overridden with **--save-passwords**)
 
 0.5.2
 -----

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,23 @@ If **verify_ssl** is set to an unknown value or to an invalid path then the
 fallback is SSL/TLS certificate verification with the default CA bundle.
 
 
+auto start
+----------
+
+It is possible both for JIRA and Redmine to 'auto start' (i.e. mark as in
+progress or something equivalent) an issue when you start tracking time for it.
+
+Simply set the corresponding config option to 'y' to activate auto start and to
+'n' to disable it.
+
+In the case of JIRA a third value is possible. This value implicitly assumes
+'y' and uses the value you set as the name of the transition. For example if
+you want to use the transition 'Working' you can set the config value to
+precisely that value. The same goes if you want to the set the transition to
+'In Progress'. Per default 'Start Progress' is used (i.e. when you specify
+'y').
+
+
 problems?
 ---------
 
@@ -157,6 +174,9 @@ changes
 * feature: add **verify_ssl** config option for JIRA and extend it for Redmine.
   It is now possible to specify [y/n/path] where path is the path to a CA
   certificate bundle
+* feature: extend **auto_start** config option for JIRA.
+  It is now possible to specify [y/n/TRANSITION_NAME] where TRANSITION_NAME is
+  the name of the transition to use instead of 'Start Progress' (default)
 
 0.5.2
 -----

--- a/hamster_bridge/__init__.py
+++ b/hamster_bridge/__init__.py
@@ -34,6 +34,8 @@ def main():
                         help='check every this amount of seconds for updates')
     parser.add_argument('--config-path', default=CONFIG_PATH, type=str, 
                         help='path to config file, defaults to {}'.format(CONFIG_PATH))
+    parser.add_argument('--save-passwords', action='store_true',
+                        help='store passwords and other sensitive data in the config file, defaults to False.')
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -43,7 +45,7 @@ def main():
     logger = logging.getLogger(__name__)
 
     logger.info('Starting hamster bridge')
-    bridge = HamsterBridge()
+    bridge = HamsterBridge(save_passwords=args.save_passwords)
     logger.debug('Activating listener: %s', args.bugtracker)
     bridge.add_listener(listener_choices[args.bugtracker]())
     bridge.configure(args.config_path)

--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -41,6 +41,7 @@ class HamsterBridge(hamster.client.Storage):
         """
         path = os.path.expanduser(config_path)
         config = ConfigParser.RawConfigParser()
+        sensitive_config = ConfigParser.RawConfigParser()
         # read from file if exists
         if os.path.exists(path):
             logger.debug('Reading config file from %s', path)
@@ -48,7 +49,7 @@ class HamsterBridge(hamster.client.Storage):
         # let listeners extend
         for listener in self._listeners:
             logger.debug('Configuring listener %s', listener)
-            listener.configure(config)
+            listener.configure(config, sensitive_config)
         # save to file
         with open(path, 'wb') as configfile:
             logger.debug('Writing back configuration to %s', path)

--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -14,14 +14,37 @@ except ImportError:
     raise ImportError('Can not find hamster')
 
 
+def _combine_configs(*configs):
+    """
+    Combines all configs (instances of RawConfigParser) into a single one
+    containing all sections and values. If duplicates appear the later configs
+    will overwrite the earlier values.
+    Returns a RawConfigParser() instance.
+    """
+    result = ConfigParser.RawConfigParser()
+    for config in configs:
+        for section in config.sections():
+            try:
+                result.add_section(section)
+            except ConfigParser.DuplicateSectionError:
+                # Ignore it. We simply want to include all sections from
+                # the source configs
+                pass
+            for option in config.options(section):
+                value = config.get(section, option)
+                result.set(section, option, value)
+    return result
+
+
 class HamsterBridge(hamster.client.Storage):
     """
     Connects to the running hamster instance via dbus. But as the notification does not work reliable there is a
     polling-based loop in the run()-method that will trigger all registered listeners.
     """
-    def __init__(self):
+    def __init__(self, save_passwords=False):
         super(HamsterBridge, self).__init__()
         self._listeners = []
+        self.save_passwords = save_passwords
 
     def add_listener(self, listener):
         """
@@ -53,7 +76,11 @@ class HamsterBridge(hamster.client.Storage):
         # save to file
         with open(path, 'wb') as configfile:
             logger.debug('Writing back configuration to %s', path)
-            config.write(configfile)
+            if self.save_passwords:
+                all_configs = _combine_configs(config, sensitive_config)
+                all_configs.write(configfile)
+            else:
+                config.write(configfile)
         # as we store passwords in clear text, let's at least set correct file permissions
         logger.debug('Setting owner only file permissions to %s', path)
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)

--- a/hamster_bridge/listeners/__init__.py
+++ b/hamster_bridge/listeners/__init__.py
@@ -1,3 +1,7 @@
+from collections import namedtuple
+
+
+ConfigValue = namedtuple('ConfigValue', ['key', 'setup_func'])
 
 
 class HamsterListener(object):
@@ -10,9 +14,9 @@ class HamsterListener(object):
         if self.short_name is not None and len(self.config_values) > 0:
             if not self.config.has_section(self.short_name):
                 self.config.add_section(self.short_name)
-            for config_key, config_value in self.config_values:
-                if not self.config.has_option(self.short_name, config_key):
-                    self.config.set(self.short_name, config_key, config_value())
+            for cv in self.config_values:
+                if not self.config.has_option(self.short_name, cv.key):
+                    self.config.set(self.short_name, cv.key, cv.setup_func())
 
     def prepare(self):
         pass

--- a/hamster_bridge/listeners/__init__.py
+++ b/hamster_bridge/listeners/__init__.py
@@ -1,7 +1,8 @@
 from collections import namedtuple
+from ConfigParser import NoOptionError
 
 
-ConfigValue = namedtuple('ConfigValue', ['key', 'setup_func'])
+ConfigValue = namedtuple('ConfigValue', ['key', 'setup_func', 'sensitive'])
 
 
 class HamsterListener(object):
@@ -9,14 +10,53 @@ class HamsterListener(object):
     short_name = None
     config_values = []
 
-    def configure(self, config):
+    def get_from_config(self, key):
+        """
+        Tries to get the value for the specified key. First in the regular
+        config, then in the sensitive_config. If it not found in either None is
+        returned.
+        """
+        try:
+            # Get from regular config
+            value = self.config.get(self.short_name, key)
+        except NoOptionError:
+            try:
+                # ... if not found get from sensitive config
+                value = self.sensitive_config.get(self.short_name, key)
+            except NoOptionError:
+                # ... if again not found return None
+                value = None
+        return value
+
+
+    def configure(self, config, sensitive_config):
+        """
+        Saves selve.config_values in 'config' or 'sensitive_config' depending
+        on whether the config value is sensitive information (e.g. a password)
+        or not.
+        """
         self.config = config
+        self.sensitive_config = sensitive_config
         if self.short_name is not None and len(self.config_values) > 0:
             if not self.config.has_section(self.short_name):
                 self.config.add_section(self.short_name)
+            if not self.sensitive_config.has_section(self.short_name):
+                self.sensitive_config.add_section(self.short_name)
             for cv in self.config_values:
-                if not self.config.has_option(self.short_name, cv.key):
-                    self.config.set(self.short_name, cv.key, cv.setup_func())
+                if cv.sensitive:
+                    if self.get_from_config(cv.key) is None:
+                        self.sensitive_config.set(
+                            self.short_name,
+                            cv.key,
+                            cv.setup_func(),
+                        )
+                else:
+                    if self.get_from_config(cv.key) is None:
+                        self.config.set(
+                            self.short_name,
+                            cv.key,
+                            cv.setup_func(),
+                        )
 
     def prepare(self):
         pass

--- a/hamster_bridge/listeners/jira.py
+++ b/hamster_bridge/listeners/jira.py
@@ -6,6 +6,7 @@ from hamster_bridge.listeners import HamsterListener
 
 import logging
 import re
+from getpass import getpass
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ class JiraHamsterListener(HamsterListener):
     config_values = [
         ('server_url', lambda: raw_input('Root url to your jira server [f.e. "http://jira.example.org"]\n')),
         ('username', lambda: raw_input('Your jira user name\n')),
-        ('password', lambda: raw_input('Your jira password\n')),
+        ('password', lambda: getpass('Your jira password\n')),
         ('auto_start', lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'))
     ]
 

--- a/hamster_bridge/listeners/jira.py
+++ b/hamster_bridge/listeners/jira.py
@@ -22,18 +22,22 @@ class JiraHamsterListener(HamsterListener):
         ConfigValue(
             key='server_url',
             setup_func=lambda: raw_input('Root url to your jira server [f.e. "http://jira.example.org"]\n'),
+            sensitive=False,
         ),
         ConfigValue(
             key='username',
             setup_func=lambda: raw_input('Your jira user name\n'),
+            sensitive=False,
         ),
         ConfigValue(
             key='password',
             setup_func=lambda: getpass('Your jira password\n'),
+            sensitive=True,
         ),
         ConfigValue(
             key='auto_start',
             setup_func=lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
+            sensitive=False,
         ),
     ]
 
@@ -41,9 +45,9 @@ class JiraHamsterListener(HamsterListener):
 
     # noinspection PyBroadException
     def prepare(self):
-        server_url = self.config.get(self.short_name, 'server_url')
-        username = self.config.get(self.short_name, 'username')
-        password = self.config.get(self.short_name, 'password')
+        server_url = self.get_from_config('server_url')
+        username = self.get_from_config('username')
+        password = self.get_from_config('password')
 
         logger.info('Connecting as "%s" to "%s"', username, server_url)
         self.jira = JIRA(server_url, basic_auth=(username, password))
@@ -74,7 +78,8 @@ class JiraHamsterListener(HamsterListener):
                         logger.exception('Error communicating with Jira')
 
     def on_fact_started(self, fact):
-        if self.config.get(self.short_name, 'auto_start') == 'y':
+        auto_start = self.get_from_config('auto_start')
+        if auto_start == 'y':
             try:
                 issue_name = self.__issue_from_fact(fact)
                 if issue_name is None:

--- a/hamster_bridge/listeners/jira.py
+++ b/hamster_bridge/listeners/jira.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 from jira import JIRA, JIRAError
 
-from hamster_bridge.listeners import HamsterListener
+from hamster_bridge.listeners import (
+    HamsterListener,
+    ConfigValue,
+)
 
 import logging
 import re
@@ -16,10 +19,22 @@ class JiraHamsterListener(HamsterListener):
     short_name = 'jira'
 
     config_values = [
-        ('server_url', lambda: raw_input('Root url to your jira server [f.e. "http://jira.example.org"]\n')),
-        ('username', lambda: raw_input('Your jira user name\n')),
-        ('password', lambda: getpass('Your jira password\n')),
-        ('auto_start', lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'))
+        ConfigValue(
+            key='server_url',
+            setup_func=lambda: raw_input('Root url to your jira server [f.e. "http://jira.example.org"]\n'),
+        ),
+        ConfigValue(
+            key='username',
+            setup_func=lambda: raw_input('Your jira user name\n'),
+        ),
+        ConfigValue(
+            key='password',
+            setup_func=lambda: getpass('Your jira password\n'),
+        ),
+        ConfigValue(
+            key='auto_start',
+            setup_func=lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
+        ),
     ]
 
     issue_from_title = re.compile('([A-Z][A-Z0-9]+-[0-9]+)')

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -29,38 +29,33 @@ class RedmineHamsterListener(HamsterListener):
         ConfigValue(
             key='server_url',
             setup_func=lambda: raw_input('Root URL to the Redmine server [f.e. "http://redmine.example.org/"]\n'),
+            sensitive=False,
         ),
         ConfigValue(
             key='api_key',
             setup_func=lambda: raw_input('Your Redmine API access key.\n'),
+            sensitive=False,
         ),
         ConfigValue(
             key='version',
             setup_func=lambda: raw_input('The Redmine version number, e.g. 2.5.1\n'),
+            sensitive=False,
         ),
         ConfigValue(
             key='auto_start',
             setup_func=lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
+            sensitive=False,
         ),
         # FIXME still usable?
         ConfigValue(
             key='verify_ssl',
             setup_func=lambda: raw_input('Verify HTTPS/SSL connections? [y/n]\n'),
+            sensitive=False,
         ),
     ]
 
     # Redmine issue key is just a number
     issue_from_title = re.compile('([0-9]+)\ ')
-
-    def __get_config(self, key):
-        """
-        Returns the config value with the given key.
-        :param key: the key to get
-        :type key: basestring
-        :return: the config value
-        :rtype: basestring
-        """
-        return self.config.get(self.short_name, key)
 
     def __init__(self):
         """
@@ -175,11 +170,11 @@ class RedmineHamsterListener(HamsterListener):
         
         # setup the redmine instance
         self.redmine = Redmine(
-            self.__get_config('server_url'),
-            key=self.__get_config('api_key'),
-            version=self.__get_config('version'),
+            self.get_from_config('server_url'),
+            key=self.get_from_config('api_key'),
+            version=self.get_from_config('version'),
             requests={
-                'verify': True if self.__get_config('verify_ssl') == 'y' else False
+                'verify': True if self.get_from_config('verify_ssl') == 'y' else False
             }
         )
         # fetch the possible activities for time entries
@@ -209,7 +204,8 @@ class RedmineHamsterListener(HamsterListener):
         :type fact: hamster.lib.stuff.Fact
         """
         # if issue shall be auto started...
-        if self.config.get(self.short_name, 'auto_start') == 'y':
+        auto_start = self.get_from_config('auto_start')
+        if auto_start == 'y':
             # fetch the issue from the hamster fact
             issue = self.__get_issue_from_fact(fact)
 

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 import logging
 import re
 
-from hamster_bridge.listeners import HamsterListener
+from hamster_bridge.listeners import (
+    HamsterListener,
+    ConfigValue,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -23,12 +26,27 @@ class RedmineHamsterListener(HamsterListener):
     short_name = 'redmine'
 
     config_values = [
-        ('server_url', lambda: raw_input('Root URL to the Redmine server [f.e. "http://redmine.example.org/"]\n')),
-        ('api_key', lambda: raw_input('Your Redmine API access key.\n')),
-        ('version', lambda: raw_input('The Redmine version number, e.g. 2.5.1\n')),
-        ('auto_start', lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n')),
+        ConfigValue(
+            key='server_url',
+            setup_func=lambda: raw_input('Root URL to the Redmine server [f.e. "http://redmine.example.org/"]\n'),
+        ),
+        ConfigValue(
+            key='api_key',
+            setup_func=lambda: raw_input('Your Redmine API access key.\n'),
+        ),
+        ConfigValue(
+            key='version',
+            setup_func=lambda: raw_input('The Redmine version number, e.g. 2.5.1\n'),
+        ),
+        ConfigValue(
+            key='auto_start',
+            setup_func=lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
+        ),
         # FIXME still usable?
-        ('verify_ssl', lambda: raw_input('Verify HTTPS/SSL connections? [y/n]\n')),
+        ConfigValue(
+            key='verify_ssl',
+            setup_func=lambda: raw_input('Verify HTTPS/SSL connections? [y/n]\n'),
+        ),
     ]
 
     # Redmine issue key is just a number


### PR DESCRIPTION
# Sensitive data

Storing the information is still possible (with the --save-passwords option). If the information is already present in the config file (as would be the case for people upgrading) then nothing changes.

The commit message of the last commit explains in detail what different usage scenarios are and how this change affects users.

# SSL certificate path

Allow specifying the path to your SSL/TLS CA certificate bundle in the *verify_ssl* config option.

I tested this successfully with JIRA but I currently don't have a Redmine instance so I couldn't test it there. All the changes are tested with JIRA.

This pull request also includes the previous changes because GitHub does not seem to support pull requests that are based on each other...

# Custom JIRA transition name

Allow specifying custom JIRA transition names (e.g. "In Progress" instead of "Start Progress" in my case)