### PR TITLE
Minor enhancement for the jira worklog part 

### DIFF
--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -97,9 +97,10 @@ class HamsterBridge(hamster.client.Storage):
                 logger.debug('Preparing listener %s', listener)
                 listener.prepare()
             logger.info('Start listening for hamster activity...')
+            now = datetime.datetime.now().replace(microsecond=0)
             while True:
+                last = now
                 now = datetime.datetime.now().replace(microsecond=0)
-                last = now - datetime.timedelta(seconds=polling_intervall)
                 for fact in self.get_todays_facts():
                     if fact.start_time is not None and last <= fact.start_time < now:
                         logger.debug('Found a started task: %r', vars(fact))


### PR DESCRIPTION
Hi,

recently our company started using jira for project management.
I'm using the hamster-timetracker for several years now and I do not want to stop using it or log my work twice.
So I was really happy to find your little helper.

One of the minor feature lacks I have found so far was the task starting time which was not set and therefore jira used the timestamp when the worklog entry was added.

I had a look in the source, played around a little bit and found a solution which fixed the issue for me.

If I find some spare time I will also think about ways to overcome the need of polling the hamster facts and the limitation to facts that have been stopped recently. Maybe this could also bring a solution for the problem of syncing changed facts to the jira worklog.

Please have a look on my changes and and tell me what you think about my ideas.

Kind regards,
  lechndo