### PR TITLE
Convert to Python3

### DIFF
--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -1,4 +1,4 @@
-import ConfigParser
+import configparser
 import datetime
 import time
 import logging
@@ -21,12 +21,12 @@ def _combine_configs(*configs):
     will overwrite the earlier values.
     Returns a RawConfigParser() instance.
     """
-    result = ConfigParser.RawConfigParser()
+    result = configparser.RawConfigParser()
     for config in configs:
         for section in config.sections():
             try:
                 result.add_section(section)
-            except ConfigParser.DuplicateSectionError:
+            except configparser.DuplicateSectionError:
                 # Ignore it. We simply want to include all sections from
                 # the source configs
                 pass
@@ -63,8 +63,8 @@ class HamsterBridge(hamster.client.Storage):
         :type config_path:  str
         """
         path = os.path.expanduser(config_path)
-        config = ConfigParser.RawConfigParser()
-        sensitive_config = ConfigParser.RawConfigParser()
+        config = configparser.RawConfigParser()
+        sensitive_config = configparser.RawConfigParser()
         # read from file if exists
         if os.path.exists(path):
             logger.debug('Reading config file from %s', path)
@@ -74,7 +74,7 @@ class HamsterBridge(hamster.client.Storage):
             logger.debug('Configuring listener %s', listener)
             listener.configure(config, sensitive_config)
         # save to file
-        with open(path, 'wb') as configfile:
+        with open(path, 'w', encoding='UTF-8') as configfile:
             logger.debug('Writing back configuration to %s', path)
             if self.save_passwords:
                 all_configs = _combine_configs(config, sensitive_config)

--- a/hamster_bridge/bridge.py
+++ b/hamster_bridge/bridge.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 try:
     import hamster.client
-except ImportError:
-    raise ImportError('Can not find hamster')
+except ImportError as ie:
+    raise ImportError('Cannot import hamster, cause: {}'.format(ie))
 
 
 def _combine_configs(*configs):

--- a/hamster_bridge/listeners/__init__.py
+++ b/hamster_bridge/listeners/__init__.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 
 ConfigValue = namedtuple('ConfigValue', ['key', 'setup_func', 'sensitive'])

--- a/hamster_bridge/listeners/jira.py
+++ b/hamster_bridge/listeners/jira.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 import os
 # MAX patch
 import sys
@@ -26,29 +26,29 @@ class JiraHamsterListener(HamsterListener):
     config_values = [
         ConfigValue(
             key='server_url',
-            setup_func=lambda: raw_input('Root url of your jira server [f.e. "http://jira.example.org"]: '),
+            setup_func=lambda: input('Root url of your jira server [f.e. "http://jira.example.org"]: '),
             sensitive=False,
         ),
         ConfigValue(
             key='username',
-            setup_func=lambda: raw_input('Your jira user name: '),
+            setup_func=lambda: input('Your jira user name: '),
             sensitive=False,
         ),
         ConfigValue(
             key='password',
-            setup_func=lambda: getpass('Your jira password: ') if sys.stdin.isatty() else raw_input(),
+            setup_func=lambda: getpass('Your jira password: ') if sys.stdin.isatty() else input(),
             sensitive=True,
         ),
         ConfigValue(
             key='auto_start',
-            setup_func=lambda: raw_input('Automatically start the issue when '
+            setup_func=lambda: input('Automatically start the issue when '
                 'you start the task in hamster?  You can also specify the name of '
                 'the JIRA transition to use.  [y/n/TRANSITION_NAME]: '),
             sensitive=False,
         ),
         ConfigValue(
             key='verify_ssl',
-            setup_func=lambda: raw_input('Verify HTTPS/SSL connections?  '
+            setup_func=lambda: input('Verify HTTPS/SSL connections?  '
                 'You can also specify the path to a CA certificate bundle.  [y/n/PATH]: '),
             sensitive=False,
         ),
@@ -106,7 +106,7 @@ class JiraHamsterListener(HamsterListener):
                     self.jira.issue(possible_issue)
                     logger.debug('Found existing issue "%s" in "%s"', possible_issue, field)
                     return possible_issue
-                except JIRAError, e:
+                except JIRAError as e:
                     if e.text == 'Issue Does Not Exist':
                         logger.warning('Tried issue "%s", but does not exist. ', possible_issue)
                     else:
@@ -117,9 +117,9 @@ class JiraHamsterListener(HamsterListener):
         if auto_start.lower() in ('n', 'false'):
             return
         elif auto_start.lower() in ('y', 'true'):
-            transition_name = u'Start Progress'
+            transition_name = 'Start Progress'
         else:
-            transition_name = unicode(auto_start, 'utf-8')
+            transition_name = str(auto_start, 'utf-8')
         try:
             issue_name = self.__issue_from_fact(fact)
             if issue_name is None:

--- a/hamster_bridge/listeners/redmine.py
+++ b/hamster_bridge/listeners/redmine.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 import os
 
 import logging
@@ -29,27 +29,27 @@ class RedmineHamsterListener(HamsterListener):
     config_values = [
         ConfigValue(
             key='server_url',
-            setup_func=lambda: raw_input('Root URL to the Redmine server [f.e. "http://redmine.example.org/"]\n'),
+            setup_func=lambda: input('Root URL to the Redmine server [f.e. "http://redmine.example.org/"]\n'),
             sensitive=False,
         ),
         ConfigValue(
             key='api_key',
-            setup_func=lambda: raw_input('Your Redmine API access key.\n'),
+            setup_func=lambda: input('Your Redmine API access key.\n'),
             sensitive=False,
         ),
         ConfigValue(
             key='version',
-            setup_func=lambda: raw_input('The Redmine version number, e.g. 2.5.1\n'),
+            setup_func=lambda: input('The Redmine version number, e.g. 2.5.1\n'),
             sensitive=False,
         ),
         ConfigValue(
             key='auto_start',
-            setup_func=lambda: raw_input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
+            setup_func=lambda: input('Automatically start the issue when you start the task in hamster? [y/n]\n'),
             sensitive=False,
         ),
         ConfigValue(
             key='verify_ssl',
-            setup_func=lambda: raw_input('Verify HTTPS/SSL connections? '
+            setup_func=lambda: input('Verify HTTPS/SSL connections? '
                 'You can also specify the path to a CA certificate bundle. [y/n/PATH]\n'),
             sensitive=False,
         ),
@@ -109,7 +109,7 @@ class RedmineHamsterListener(HamsterListener):
             """
             Filter function to find the in work status.
             """
-            return element.name in [u'In Bearbeitung', u'In Work']
+            return element.name in ['In Bearbeitung', 'In Work']
 
         # get the issue statuses
         issue_statuses = self.redmine.issue_status.all()
@@ -150,7 +150,7 @@ class RedmineHamsterListener(HamsterListener):
             # this grabs the first activity from the dict
             return self.__get_first_activity_id()
         else:
-            for activity_id, activity_value in self.__activities.viewitems():
+            for activity_id, activity_value in self.__activities.items():
                 try:
                     next(tag for tag in tags if tag == activity_value[0])
                     return activity_id

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='hamster-bridge',
     description='let your hamster log your work to your favorite bugtracker',
-    version='0.7.0',
+    version='0.8.0',
     author='Lars Kreisz',
     author_email='lars.kreisz@gmail.com',
     license='MIT',
@@ -16,5 +16,9 @@ setup(
     packages=['hamster_bridge', 'hamster_bridge.listeners'],
     entry_points={'console_scripts': ['hamster-bridge = hamster_bridge:main']},
     long_description=open('README.rst').read(),
-    install_requires=['jira>=0.41']
+    install_requires=[
+        'configparser>=4.0.0',
+        'jira>=0.41',
+        'python-dateutil>=2.8.0',
+    ]
 )


### PR DESCRIPTION
This converts the code to Python 3, to make it usable with latest version of Hamster and other Python libraries.

It's based on the source branch of #31 I proposed several minutes ago; I am hoping this makes merging both PRs easier (while leaving the option for Python 2 users to pick the version with only #31 merged).